### PR TITLE
Adding basic authentication of wms

### DIFF
--- a/TomBio/nbndialog.py
+++ b/TomBio/nbndialog.py
@@ -188,18 +188,18 @@ class NBNDialog(QWidget, Ui_nbn):
         #selectedTVK = "NHMSYS0000530739"
         
         #Get the map from NBN
-        url = 'url=https://gis.nbn.org.uk/SingleSpecies/'
+        url = ''
+
+        #Set user login stuff
+        if not self.leUsername.text() == "":
+            url = url + "username=" + self.leUsername.text()
+            url = url + ",password=" + self.lePassword.text() + ','
+
+        url = url + 'url=https://gis.nbn.org.uk/SingleSpecies/'
         
         #Taxon
         url = url + selectedTVK 
         
-        #Set user login stuff
-        if not self.leUsername.text() == "":
-            url = url + "&username=" + self.leUsername.text()
-            #url = url + "&userkey=" + self.nbnAthenticationCookie.value
-            hashed_password = hashlib.md5(self.lePassword.text()).hexdigest()
-            url = url + "&userkey=" + hashed_password
-            #self.iface.messageBar().pushMessage("Info", "Hash is: " + hashed_password, level=QgsMessageBar.INFO)
             
         #Set layer stuff
         strStyles="&styles="


### PR DESCRIPTION
Hey Richard,

One of the other developers for the NBN Gateway mentioned about your QGIS plugin. I've had a look and am very impressed.

I am also aware that you have an issue regarding the authentication. One potential way for this to work could be to use Basic Authentication. This pull request documents how that could work in your QGIS plugin.

Currently the NBN Gateway GIS system **doesn't** support Basic Authentication, however I have put forward a pull request for the NBN Gateway code base so that it does.

@mattdebont will be reviewing this pull request and if he accepts, then your QGIS plugin should be able to authenticate.

@mattdebont would you be able to let @burkmarr know if/when this feature goes live?

Cheers,

Chris
